### PR TITLE
update 5p empty clue table

### DIFF
--- a/other-conventions/Empty_Clues.md
+++ b/other-conventions/Empty_Clues.md
@@ -43,12 +43,12 @@
 
 | # mod 6    | action          | type of clue
 | ---------- | --------------- | -------------
-| 0 (6, 12)  | clue or discard | green or yellow
+| 0 (6, 12)  | clue or discard | red or black
 | 1 (7, 13)  | play 1          | number 1 or blue
-| 2 (8, 14)  | play 2          | number 2
-| 3 (9, 15)  | play 3          | number 3 or red
-| 4 (10, 16) | play 4          | number 4 or purple
-| 5 (11, 17) | chop move       | number 5 or black
+| 2 (8, 14)  | play 2          | number 2 or green
+| 3 (9, 15)  | play 3          | number 3 or yellow
+| 4 (10, 16) | play 4          | number 4
+| 5 (11, 17) | chop move       | number 5
 
 * The chop move in action 5 is only allowed if the player has:
   * a globally-known critical card on chop


### PR DESCRIPTION
I don't know if we should add this, but in a variant with 6 color clues, it should be:
```
purple/orange/black
1/blue
2/green
3/yellow
4/red
5
```
In a variant with 4 color clues it should be
```
rightmost 2 colors
1/leftmost color
2/2nd color
3
4
5
```