### PR TITLE
Remove copy+paste error in text.

### DIFF
--- a/examples/Clandestine_Bubblegum_Finesse.md
+++ b/examples/Clandestine_Bubblegum_Finesse.md
@@ -11,7 +11,6 @@
 * Kyle knows that duckmammal's number 1 clue got Dr_Kakashi to blind-play, so something special must have happened, meaning that the 1 that he has in his hand is probably not a normal playable 1. This must be a *Bubblegum Finesse*, so the card in his hand must be the pink 2 in order to match the pink 1 was that blind-played.
 * However, Kyle also sees that in Dr_Kakashi's hand, there is a pink 2 behind the pink 1. If this is a *Clandestine Bubblegum Finesse*, then Dr_Kakashi will play the pink 2, which means that Kyle will have the pink 3 to match. If Dr_Kakashi does not blind-play the pink 2, then it means that Kyle really does have the pink 2. Either way, Kyle has to give Dr_Kakashi one turn to demonstrate what is happening.
 * Kyle clues 2's to to Dr_Kakashi, touching the 2's as a *2 Save* on the green 2. (This should not interfere with Dr_Kakashi's ability to play the pink 2 and show that he is *Clandestine Finessed*.)
-breaking clues number 5 to invarse. That touches the blue 5. Since the blue 5 is one-away from chop, invarse will think that this is a *5's Chop Move*.
 * duckmammal plays the blue 1.
 * Dr_Kakashi knows that if he does not play the pink 2, Kyle will go on to think that he has the pink 2, and the team will get a strike. Thus, Dr_Kakashi knows that duckmammal promised him to have the pink 2. Dr_Kakashi plays the pink 2 from slot 2.
 * Kyle now knows that his card marked with a number 1 clue he must be the pink 3.


### PR DESCRIPTION
Removing text "breaking clues number 5 to invarse. That touches the blue 5. Since the blue 5 is one-away from chop, invarse will think that this is a *5's Chop Move*." that seems to be a copy+paste error.