### PR TITLE
Update Reference.md

### DIFF
--- a/Reference.md
+++ b/Reference.md
@@ -2456,10 +2456,10 @@ There are a lot of different moves that involve cluing trash. [Here is a handy f
 
 ### The Distribution Finesse
 
-* On the final round of the game, it is possible to perform a *Prompt* on a player that would be useless - they will not get a chance to play the *Prompted* card before the game ends.
-* If a player does this anyway, then it must be communicating something extra. In this situation, it is to be interpreted as a *Finesse* instead of a *Prompt* for the purposes of better satisfying *Team Distribution Principle*.
+* On the final round of the game, it is possible to give a *Play Clue* to a player that would be useless - they will not get a chance to play the card before the game ends.
+* If a player does this anyway, then it must be communicating something extra. In this situation, it is to be interpreted as a *Finesse* instead of a *Play Clue* for the purposes of better satisfying *Team Distribution Principle*.
 * Examples:
-  * Game #16887, turn 29 if Instantiation clues blue on the blue 5
+  * Game #16887, turn 29 if Instantiation clues 5 on the red 5
 
 ### Inverted Priority Finesse
 


### PR DESCRIPTION
This convention confuses me, because usually a prompt would have very high priority in lategame, and could be seen as a way to change the priorities of the player. Also, in the given example, blue clue to the blue 5 touches trash on either side of the 5 and makes no sense. I think what's intended is a play clue to red 5, which would indeed be useless, and hence trigger a finesse to move the red 4 into a different hand.