### PR TITLE
Fix two outdated references

### DIFF
--- a/Reference.md
+++ b/Reference.md
@@ -863,7 +863,7 @@ Note that in this user interface, players are **not** holding their hands like t
 * In order to squeeze as much value out of the conventions as possible, we have some extra rules about "extinguishing" every possible clue:
   * Extinguishing every clue **does** include *5 Stalling*, but it is only mandatory for the team to collectively perform one *5 Stall*. If one *5 Stall* clue has already been given and there is another *5 Stall* clue available, players are allowed (but not required) to clue it.
   * Extinguishing every clue **does not** include cluing something in the hand of the player who came directly before. This is because the player who came before did not see anything for the next player to do, and is therefore giving them "permission" to discard. In this situation, cluing is optional; players can choose to either clue the previous hand or discard at their discretion.
-  * Extinguishing every clue **does not** include cluing cards that will be almost certainly be *Order Chop Moved* by an upcoming player who already has two or more 1's clued in their hand. (*Order Chop Moves* are an advanced move that is covered later.)
+  * Extinguishing every clue **does not** include cluing cards that will be almost certainly be *Order Chop Moved* by an upcoming player who already has two or more 1's clued in their hand.
 
 ### 5 Stalls (Intermediate Section)
 
@@ -895,7 +895,7 @@ Note that in this user interface, players are **not** holding their hands like t
 | 4 (tied)   | Filling in extra info on clued cards or *Chop Moved* cards                            | ❌ | ✔ | ✔ | ✔
 | 5          | *Hard Burn* (re-cluing an unplayable card that gives no new information, usually a 5) | ❌ | ✔ | ✔ | ✔
 
-* For example, if a player could perform a *5 Stall* (precedence 2), then they are not allowed to perform a *Tempo Clue* (precedence 3). Or, if a player could perform a *Tempo Clue* (precedence 3), they are not allowed to *Hard Burn* (precedence 7), and so forth.
+* For example, if a player could perform a *5 Stall* (precedence 2), then they are not allowed to perform a *Tempo Clue* (precedence 3). Or, if a player could perform a *Tempo Clue* (precedence 3), they are not allowed to *Hard Burn* (precedence 5), and so forth.
   * However, remember that the *Finesse Position Exception* applies to *5 Stalls*. (This is covered in the "5 Stall" section above.)
 * What is the point of having a complicated table with defined priorities? Well, normally, players in stalling situations are not able to give tricky-looking *Finesses*, because everyone else on the team will think that they are giving a stall clue. However, if it can be seen that there is a better clue available for them to give, then everyone can know that they are **not** giving a stall clue. Thus, because of this precedence table, players in stalling situations are still often able to make *Finesses* happen.
 * Obviously, stall clues are not allowed when the player has a known playable card in their hand.


### PR DESCRIPTION
In the last bullet of the "The Early Game (Intermediate Section)" there was a parenthetical note about "Order Chop Move" being an "Advanced" move that would be introduced later. But, it's actually already been introduced in Level 5 - Apprentice.

Also, below the "Allowable Stall Clues" table, there was a reference to Hard Burns being precedence 7. When, the table actually shows them as precedence 5. (I assume they used to be precedence 7, but that the reference wasn't updated when precedences 4-6 were collapsed into a single tied precedence 4.