### PR TITLE
Corrections for "The Ambiguous Finesse Pass-Back"

### DIFF
--- a/Reference.md
+++ b/Reference.md
@@ -1346,10 +1346,10 @@ Note that in this user interface, players are **not** holding their hands like t
   * Cathy sees that Bob has the blue 2 on his *Finesse Position* and the blue 3 on his *Second Finesse Position*.
   * Cathy also knows that the only reason that Bob would discard is if Cathy **also** had the blue 2 on her *Finesse Position*. Thus, Bob expects her to blind-play on this turn, and this is an *Ambiguous Finesse*.
   * Normally, Cathy would blind-play the blue 2 herself. However, in this situation, if she blind-plays the blue 2, then Bob would go on to misplay the other blue 2, thinking that it is blue 3.
-  * Thus, Cathy must pretend like the *Finesse* is not on her all, and force Bob to be the one to blind-play first. Cathy discards her chop card, passing the *Finesse* back to Bob.
+  * Thus, Cathy must pretend like the *Finesse* is not on her after all, and force Bob to be the one to blind-play first. Cathy discards her chop card, passing the *Finesse* back to Bob.
   * Donald and Alice discard.
   * Bob knows that Cathy was supposed to blind-play the blue 2, but she didn't. He must also have the blue 2. Furthermore, he must also have the blue 3, as that would be an excellent reason for Cathy to pass the *Finesse* back to him. Bob will now blind-play blue 2 and blue 3.
-* As a side note, you may be wondering why, in the above example, Cathy does not blind-discard her blue 2 from her *Finesse Position* instead of discarding her chop. This is because it is possible that Cathy does **not** have the blue 2 on her *Finesse Position* and instead has some other unrelated playable card as a *Layered Finesse*. Thus, Cathy must play it safe and discard her chop. (The *Layered Finesse* is a move covered in a later section.)
+* As a side note, you may be wondering why, in the above example, Cathy does not blind-discard her blue 2 from her *Finesse Position* instead of discarding her chop. This is because it is possible that Cathy does **not** have the blue 2 on her *Finesse Position* and instead has some other unrelated playable card as a *Layered Finesse*. Thus, Cathy must play it safe and discard her chop. (The *[Layered Finesse](#the-layered-finesse)* is a move covered in *Level 4 - Rookie*.)
 
 ### The Trash Order Chop Move
 


### PR DESCRIPTION
Here, I correct one type adding the word "after" to the phrase "after all".

I've also taken the liberty to directly link to "Layered Finesse" and to name the level in which the convention is actually introduced. In the old version, it says that it is covered "in a later section.", but it's actually covered earlier in the document.