### PR TITLE
Specify further the rules of 5 Pull Finesses

### DIFF
--- a/Reference.md
+++ b/Reference.md
@@ -1978,8 +1978,9 @@ Priority does not always apply. Some common exceptions are listed below.
   * Thus, this must be a *5 Pull Finesse*, so Bob blind-plays his *Finesse Position*. It is red 1 and it successfully plays.
   * From Cathy's perspective, she initially concluded that Alice's number 5 clue was just a *5 Stall*. However, Bob blind-played his *Finesse Position* card, and Cathy knows that Bob would not do that if the move was a *5 Stall*. This must be a *5 Pull Finesse*, so Cathy blind-plays her slot 4 card. It is red 2 and it successfully plays.
 * As you would expect, it is also possible to perform a *5 Pull Double Finesse*. The "pulled" card will always match the final blind-play.
-* Unlike other types of *Finesses*, *5 Pulls* are **not** allowed to initiate a *Reverse Finesse*. (This is because we don't want the person with the pulled card to have to entertain too many possibilities.)
-* With that said, players **do** have to respect that forward *5 Pull Finesses* could be *Layered* or *Clandestine*.
+* Unlike other types of *Finesses*, *5 Pull Finesses* must be demonstrated with a blind-play between when the *5 Pull* is given and the *5 Pulled* player's next turn.
+* Subsequently, *5 Pulls* are **not** allowed to initiate a *Reverse Finesse*. (This is because we don't want the person with the pulled card to have to entertain too many possibilities.)
+* With that said, players **do** have to respect that forward *5 Pull Finesses* could be *Layered*, *Clandestine*, or have a "*Reverse Finesse*-component".
 * Remember that during a *5 Pull Finesse*, the pulled card **always** matches the blind-play. In other words, it generally impossible to ever perform a *5 Pull Bluff*, a *5 Pull Double Bluff*, a *5 Pull Pestilent Double Bluff*, and so on.
 
 ### The 5 Pull Promise (A Follow-up Play Clue After a 5 Pull)


### PR DESCRIPTION
This is just my working understanding and I would love feedback.

I also have one question. There's a scenario that some experts say is legal but would conflict with this wording.

- Cathy has one clued 1 in her hand - the red 1.
- Donald has a red 2 on finesse position
- Alice does a *5 Pull* on Bob's red 3
- Alice expects Bob to wait for red 1 to play before blind-playing.
- Bob discards.
- Cathy plays red 1
- Donald blind-plays red 2
- Alice discards
- Bob blind-plays red 3

Is Bob required to delay his blind-play even if he knows that his pulled card cannot be red 2? For example, if he sees the other copy in Alice's hand

If he is required to delay it, then this clue by Alice seems perfectly legal. In which case the wording used in this commit ".., must be demonstrated with a blind-play before the pulled player's next turn" is incorrect.