### PR TITLE
Mention saving critical 2's with color in the beginner's guide

### DIFF
--- a/Beginner.md
+++ b/Beginner.md
@@ -153,6 +153,7 @@ In this guide, there will be some screenshots to show off the concepts introduce
 
 * For the same reason that 5's need to be saved, critical cards also need to be saved. (Critical cards are defined as cards that have the other copy discarded.)
 * Players can choose to save critical cards with either a color clue **or** a number clue.
+  * Note that this even applies to 2's in the rare case that a copy of that 2 ends up in the discard pile.
 * In the above screenshot:
   * The current discard pile is shown to the right of the hands.
   * Alice clues Bob yellow, which touches a card on slot 4.
@@ -160,6 +161,7 @@ In this guide, there will be some screenshots to show off the concepts introduce
   * This could be a *Play Clue* on the yellow 2. However, since the clue was focused on his chop, this could also be a *Save Clue*.
   * Bob looks through the discard pile and finds that there is a yellow 4 there. Thus, this could be a *Save Clue* on the yellow 4. So, Bob knows that for now, he has to hold on to the card.
   * Bob marks the card as either a yellow 2 or a yellow 4, so that he can keep track of it for later. Then, he discards.
+
 
 <br />
 

--- a/Beginner.md
+++ b/Beginner.md
@@ -162,7 +162,6 @@ In this guide, there will be some screenshots to show off the concepts introduce
   * Bob looks through the discard pile and finds that there is a yellow 4 there. Thus, this could be a *Save Clue* on the yellow 4. So, Bob knows that for now, he has to hold on to the card.
   * Bob marks the card as either a yellow 2 or a yellow 4, so that he can keep track of it for later. Then, he discards.
 
-
 <br />
 
 ### Play Clues


### PR DESCRIPTION
I'm tired of hearing that saving critical 2's with color is level 6. That said, I'm not sure whether this change actually improves the beginner's guide.