### PR TITLE
Loaded white play clues

### DIFF
--- a/variant-specific/White.md
+++ b/variant-specific/White.md
@@ -16,11 +16,10 @@ These conventions apply to any variant with a white (colorless) suit.
 
 ### White Loaded Play Clues
 
-- Saves are sometimes interpreted as *Loaded Play Clues*
 - A rank clue focusing a player's chop should be interpreted as a *White Loaded Play Clue* if the recipient is loaded, the focused card could be white, and at least one of the following is true:
   
   1. The white card of the rank clued is playable.
-  2. The white card of the rank clued is a critical, 2, or 5.
+  2. The white card of the rank clued is critical, or this was a 2 clue.
 - The one exception to the above is for saving 5's in *Early Game*. A clue to a 5 on chop in *Early Game* is not interpreted as a *White Loaded Play Clue* even if the 5 may be white.
 - For example, in a 3-player game (*White Loaded Play Clue*):
   - White 2 is on the stacks, green 3 is in the trash.

--- a/variant-specific/White.md
+++ b/variant-specific/White.md
@@ -13,3 +13,28 @@ These conventions apply to any variant with a white (colorless) suit.
 
 - When you clue a white 5 in the *Early Game* that is two or more away from chop, it would normally look like a *5 Pull*.
 - However, if there are white cards visible and it could be a *Finesse* on the white 5, then it should be treated as a *Finesse* instead of a *5 Pull*.
+
+### White Loaded Play Clues
+
+- Saves are sometimes interpreted as *Loaded Play Clues*
+- A rank clue focusing a player's chop should be interpreted as a *White Loaded Play Clue* if the recipient is loaded, the focused card could be white, and at least one of the following is true:
+  
+  1. The white card of the rank clued is playable.
+  2. The white card of the rank clued is a critical, 2, or 5.
+- The one exception to the above is for saving 5's in *Early Game*. A clue to a 5 on chop in *Early Game* is not interpreted as a *White Loaded Play Clue* even if the 5 may be white.
+- For example, in a 3-player game (*White Loaded Play Clue*):
+  - White 2 is on the stacks, green 3 is in the trash.
+  - Bob has a clued playable 1 in his hand.
+  - Alice clues Bob 3 to Bob's chop.
+  - Bob notices that white 3 is playable and that he is loaded, so Bob determines that this is a *White Loaded Play Clue*. Bob writes white 3 on his recently clued card and plays it correctly
+- For example, in a 3-player game (*White Loaded Play Clue*):
+  - White 1 is on the stacks, white 3 and green 3 are in the trash.
+  - Bob has a clued playable 1 in his hand.
+  - Alice clues Bob 3 to Bob's chop.
+  - Bob notices that white 3 is in the trash, which means that this clue could be a save on a white card. Bob determines that this is a *White Loaded Play Clue* and writes white 3 on his recently clued card.
+  - Bob doesn't see white 2 on Cathy's finesse, so writes white 2 on his own finesse and plays it correctly
+- For example, in a 3-player game (Not a *White Loaded Play Clue*):
+  - White 1 is on the stacks, green 3 is in the trash.
+  - Bob has a clued playable 1 in his hand.
+  - Alice clues Bob 3 to Bob's chop.
+  - Bob notices that there is no white 3 in the trash and white 2 is not playable. Bob determines that this is not a *White Loaded Play Clue* and writes green 3 on his recently clued card.


### PR DESCRIPTION
Loaded White Play Clues. Expands the ability to give loaded play clues to white cards on chop at the cost of limiting the ability to give loaded save clues.

This would've been useful here: https://hanab.live/shared-replay/384380#14