### PR TITLE
Unify Pink Promise with 5 Stall/5 Chop Move and move them up

### DIFF
--- a/docs/variant-specific/pink.mdx
+++ b/docs/variant-specific/pink.mdx
@@ -401,7 +401,7 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
 
 <FakeFinesse />
 
-## Edge Cases
+## Level 21 - Edge Cases
 
 ### Trash Moves in Pink
 


### PR DESCRIPTION
It seems weird to me that "Pink Promise with 5 Stall" and "Pink Promise with a 5 Chop Move" are listed under Edge Cases (classified as level 21). Because these conventions say essentially the same thing -- that's why I unified them under a single section -- and they relate to common clues, I think they should be moved up under "Basic pink principles" so that people starting to play Pink are aware of them. This PR also include minor edits to "Pink Promise with a 5 Pull" (added a comment on the rare 3-player case of a 5 Pull performed on slots 1 and 3.)

