### PR TITLE
5 Stall clarification (level 9)

### DIFF
--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -130,7 +130,7 @@ import FiveStall from "./level-9/five-stall.yml";
 
 #### 5 Stalls are a Last Resort
 
-- _5 Stalls_ **must** be a last resort. Specifically, this means that the player giving a _5 Stall_ must not have any immediately playable cards and not have any other visible _Play Clues_ and _Save Clues_ to give.
+- _5 Stalls_ **must** be a last resort. Specifically, this means that the player giving a _5 Stall_ must not have any immediately playable cards or a known safe discard and not have any other visible _Play Clues_ and _Save Clues_ to give.
 - This "last resort" principle applies to _5 Stalls_ given in both the _Early Game_ and the _Mid-Game_.
 - However, see the _Finesse Position Exception_ section below.
 


### PR DESCRIPTION
The "having a safe discard" test is mentioned in the level 19 flowchart for 5 tech but not at level 9. I think it could also be put here to be more visible.