### PR TITLE
Clarify wording of elimination play clue

### DIFF
--- a/docs/level-18.mdx
+++ b/docs/level-18.mdx
@@ -69,7 +69,7 @@ import TrashTouchEliminationInteraction from "./level-18/trash-touch-elimination
 ### The Elimination Play Clue
 
 - A clue that touches multiple cards only has one focus. As you probably know, if the chop card was not touched, then the focus is the leftmost card.
-- However, this rule does not apply if a clue singles out an immediately playable card from _Elimination_. In this case, the card is only focused on the _Elimination_ card, and any other cards touched are not necessarily playable right now.
+- However, this rule does not apply if a clue singles out an immediately playable card from _Elimination_. In this case, the clue only focuses on the _Elimination_ card, and any other cards touched are not necessarily playable right now.
 - For example, in a 3-player game:
   - Red 1 and blue 1 are played on the stacks.
   - Alice has both red 2's in her hand on slot 2 and slot 5. (Alice's chop is her slot 5.)


### PR DESCRIPTION
The old wording was nonsensical, mixing up the words 'clue' and 'card'. I fixed the wording, also mildly editing the half-sentence to be more clear (the meaning is the same, but now it actually makes sense).