### PR TITLE
Remove outdated specification interaction between prio and GD's on 1

### DIFF
--- a/docs/level-25.mdx
+++ b/docs/level-25.mdx
@@ -303,7 +303,7 @@ Priority does not always apply. Some common exceptions are listed below.
 #### 3) Blind-Playing Globally Known Cards
 
 - Normally, blind-playing cards has _Priority_ over everything else.
-- However, in some advanced cases, the blind-play does not need to be demonstrated to the team - everyone already has full knowledge of what is going on. In this case, players are supposed to treat the cards as clued for the purposes of finding the _Priority_. (The _Gentleman's Discard_ on a non-1 is the main move that this applies to.)
+- However, in some advanced cases, the blind-play does not need to be demonstrated to the team - everyone already has full knowledge of what is going on. In this case, players are supposed to treat the cards as clued for the purposes of finding the _Priority_. (The _Gentleman's Discard_ is the main move that this applies to.)
 
 #### 4) "Important" Cards
 


### PR DESCRIPTION
Since ambiguous GDs of a 1 (when both other 1s of that colour are on different finesse positions) are now illegal, this line can be simplified.