### PR TITLE
Clarifying Exception to Extinguishing Every Clue in Early Game

### DIFF
--- a/docs/level-9.mdx
+++ b/docs/level-9.mdx
@@ -59,7 +59,7 @@ import FiveStall from "./level-9/five-stall.yml";
 
 #### Extinguishing Every Clue
 
-- Extinguishing every clue **does not** include giving clues that would violate _Good Touch Principle_. (For example, if someone has two copies of red 1 in their hand, then the standard solution is to wait until one of the copies is discarded.)
+- Extinguishing every clue **does not** include giving _Play Clues_ that would violate _Good Touch Principle_. (For example, if someone has two copies of red 1 in their hand, then the standard solution is to wait until one of the copies is discarded.)
 - Extinguishing every clue **does not** include giving _Tempo Clues_ (e.g. clues that do not meet _Minimum Clue Value Principle_).
 - Extinguishing every clue **does not** include cluing cards that will be almost certainly be _Order Chop Moved_ by an upcoming player who already has two or more 1's clued in their hand.
 - Extinguishing every clue **does not** include cluing something in the hand of the player who came directly before. See the _[Permission to Discard](#permission-to-discard-ptd)_ section.


### PR DESCRIPTION
I was playing with a beginner who had probably read ahead but was still playing at lvl 1 and ended early game when a 2 save was available to him. He explained in the review that since that 2 save would have bad-touched another 2 that was on the stacks he thought he was exempt from cluing it. He said he had read this in the doc but we couldn't find it in the level 1 part of the doc. This is the only place where I've been able to find that axis of confusion arising, so I'm clarifying that this exception only includes Play Clues.