### PR TITLE
Removing Sentence Redundancy in Clue-Focus Flowchart

### DIFF
--- a/docs/level-1.mdx
+++ b/docs/level-1.mdx
@@ -55,7 +55,7 @@ D1[/Did it touch one or more cards for the first time?\]
 D1Y([Yes])
 D1N([No])
 D1NL(The focus is on the left-most re-touched card.)
-D2[/Was the chop card touched for the first time?\]
+D2[/Was the chop card touched?\]
 D2Y([Yes])
 D2N([No])
 D2YL(The focus is on the chop card.)


### PR DESCRIPTION
Chop card can never be re-touched.