### PR TITLE
Images: Easier player names and spacing

### DIFF
--- a/docs/example-images.mdx
+++ b/docs/example-images.mdx
@@ -9,6 +9,8 @@ import SimpleResult from "./example-images/simple.yml";
 
 import TextNameSource from "!raw-loader!./example-images/text-name.yml";
 import TextNameResult from "./example-images/text-name.yml";
+import OffsetNameSource from "!raw-loader!./example-images/offset-name.yml";
+import OffsetNameResult from "./example-images/offset-name.yml";
 
 import TypesSource from "!raw-loader!./example-images/types.yml";
 import TypesResult from "./example-images/types.yml";
@@ -104,9 +106,13 @@ There are 2 main sections: `stacks` and `players`.
 
 Players are assigned the following names automatically: Alice, Bob, Cathy, Donald, and Emily. It is possible to override this with the `name` attribute. For example, this could be useful if Bob's hand is shown twice, before and after something happens.
 
-`players` can also contain a `text` instead of `cards`. This is used to describe something that happens in a game.
+`players` can also contain a `text` or `space` instead of `cards`. The first on is used to describe something that happens in a game. The second to add some vertical space.
 
 <Example code={TextNameSource} Image={TextNameResult} />
+
+Additionally, `players` can also contain an `offset` to change player names.
+
+<Example code={OffsetNameSource} Image={OffsetNameResult} />
 
 ### Cards
 

--- a/docs/example-images/offset-name.yml
+++ b/docs/example-images/offset-name.yml
@@ -1,0 +1,20 @@
+stacks:
+  - r: 0
+  - b: 5
+  - m: 3
+players:
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+        clue: r
+  - text: Bob reinterprets his hand
+  - offset: -1
+    cards:
+      - type: x
+      - type: x
+      - type: r2

--- a/docs/example-images/text-name.yml
+++ b/docs/example-images/text-name.yml
@@ -13,3 +13,26 @@ players:
       - type: x
       - type: x
       - type: x
+  - name: "Space:"
+    cards:
+      - type: x
+      - type: x
+      - type: x
+  - space: 5
+  - name: Small
+    cards:
+      - type: x
+      - type: x
+      - type: x
+  - space
+  - name: Default
+    cards:
+      - type: x
+      - type: x
+      - type: x
+  - space: 100
+  - name: Large
+    cards:
+      - type: x
+      - type: x
+      - type: x

--- a/docs/extras/discards-misplays/cautious-generation-discard.yml
+++ b/docs/extras/discards-misplays/cautious-generation-discard.yml
@@ -16,15 +16,13 @@ players:
         above: Red 4
       - type: x
   - text: Alice discards
-  - name: Bob
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x
       - type: x
       - type: x
-  - name: Cathy
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x

--- a/docs/extras/discards-misplays/promise-clue.yml
+++ b/docs/extras/discards-misplays/promise-clue.yml
@@ -34,15 +34,13 @@ players:
       - type: x
       - type: x
   - text: Cathy discards Slot 1
-  - name: Donald
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: r
         clue: r
       - type: x
-  - name: Emily
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x

--- a/docs/extras/ejection-extensions/double-ejection.yml
+++ b/docs/extras/ejection-extensions/double-ejection.yml
@@ -20,16 +20,14 @@ players:
         border: false
       - type: g4
         border: false
-  - name: Cathy
-    cards:
+  - cards:
       - type: r1
         border: false
       - type: b2
         border: false
       - type: x
       - type: x
-  - name: Donald
-    cards:
+  - cards:
       - type: r2
         clue: r
         retouched: true

--- a/docs/extras/ejection-extensions/out-of-position-ejection.yml
+++ b/docs/extras/ejection-extensions/out-of-position-ejection.yml
@@ -17,15 +17,13 @@ players:
       - type: 5
       - type: 5
   - text: Bob discards
-  - name: Cathy
-    cards:
+  - cards:
       - type: x
       - type: x
         above: Red 2
       - type: x
       - type: x
-  - name: Donald
-    cards:
+  - cards:
       - type: x
         clue: r
         above: Red 5

--- a/docs/extras/special-bluffs/known-priority-bluff.yml
+++ b/docs/extras/special-bluffs/known-priority-bluff.yml
@@ -12,16 +12,14 @@ players:
       - type: b5
       - type: x
   - text: Alice plays Blue 4
-  - name: Bob
-    cards:
+  - cards:
       - type: x
         above: Green 3
       - type: x
       - type: x
       - type: r2
       - type: x
-  - name: Cathy
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x

--- a/docs/extras/special-finesses/ambiguous-finesse-pass-back.yml
+++ b/docs/extras/special-finesses/ambiguous-finesse-pass-back.yml
@@ -19,16 +19,14 @@ players:
       - type: x
       - type: x
   - text: Bob discards
-  - name: Cathy
-    cards:
+  - cards:
       - type: x
         above: Blue 2
       - type: x
       - type: x
       - type: x
   - text: Cathy discards
-  - name: Donald
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x

--- a/docs/extras/special-finesses/certain-finesse-exception.yml
+++ b/docs/extras/special-finesses/certain-finesse-exception.yml
@@ -22,9 +22,8 @@ players:
       - type: x
       - type: x
   - text: Bob performs a Certain Discard of Slot 1, it is Red 3
-  - text: ""
-  - name: Cathy
-    cards:
+  - space
+  - cards:
       - type: x
       - type: x
       - type: x

--- a/docs/extras/special-finesses/inverted-priority-finesse.yml
+++ b/docs/extras/special-finesses/inverted-priority-finesse.yml
@@ -13,16 +13,14 @@ players:
       - type: x
       - type: x
   - text: Alice plays Red 1
-  - name: Bob
-    cards:
+  - cards:
       - type: x
         above: Red 2
       - type: x
       - type: x
       - type: x
       - type: x
-  - name: Cathy
-    cards:
+  - cards:
       - type: x
         above: Blue 3
         middleNote: b3

--- a/plugins/hanabiDocusaurusPlugin/plugin/src/convertYAMLToSVG.ts
+++ b/plugins/hanabiDocusaurusPlugin/plugin/src/convertYAMLToSVG.ts
@@ -7,6 +7,7 @@ import type {
   Card,
   HanabiGameState,
   Player,
+  Space,
   Stack,
   Text,
   TextObject,
@@ -176,16 +177,28 @@ class ImageGenerator {
     this.leftYOffset = yOffset;
   }
 
-  private drawPlayerRows(players?: ReadonlyArray<Player | Text>) {
+  private drawPlayerRows(
+    players?: ReadonlyArray<Player | Text | Space | string>,
+  ) {
     if (players === undefined) {
       return;
     }
+    let playerNum = 0;
 
-    for (const [playerNum, playerOrText] of players.entries()) {
-      if ("text" in playerOrText) {
+    for (const playerOrText of players) {
+      if (typeof playerOrText === "string") {
+        // "space" is the only allowed literal.
+        this.drawTextSeparator("", 25);
+      } else if ("space" in playerOrText) {
+        this.drawTextSeparator("", playerOrText.space);
+      } else if ("text" in playerOrText) {
         this.drawTextSeparator(playerOrText.text);
       } else {
+        if (playerOrText.offset !== undefined) {
+          playerNum += playerOrText.offset;
+        }
         this.drawPlayer(playerNum, playerOrText);
+        playerNum++;
       }
     }
   }
@@ -194,14 +207,14 @@ class ImageGenerator {
    * Draw a text separator between a player to describe some event taking place.
    * e.g. "After discarding the 1..."
    */
-  private drawTextSeparator(text: string | null) {
+  private drawTextSeparator(text: string | null, offset = 50) {
     this.svgFile.addText(text, {
       x: this.xOffsetWherePlayerBegins + 40,
       y: this.yOffset,
       dy: 20,
       class: TEXT_COLOR_CLASS,
     });
-    this.yOffset += 50;
+    this.yOffset += offset;
   }
 
   /** Draw a row representing a player's hand. */

--- a/plugins/hanabiDocusaurusPlugin/plugin/src/hanabiGameState.ts
+++ b/plugins/hanabiDocusaurusPlugin/plugin/src/hanabiGameState.ts
@@ -80,6 +80,7 @@ const player = z
     name: z.coerce.string().min(1).optional(),
     clueGiver: z.boolean().optional(),
     cards: z.array(card).readonly(),
+    offset: z.int().optional(),
   })
   .strict()
   .readonly();
@@ -94,6 +95,13 @@ const text = z
   .strict()
   .readonly();
 
+const space = z
+  .object({
+    space: z.coerce.number(),
+  })
+  .strict()
+  .readonly();
+
 export const hanabiGameStateSchema = z
   .object({
     suits: z
@@ -103,7 +111,10 @@ export const hanabiGameStateSchema = z
     stacks: z.array(stack).readonly().optional(),
     discarded: z.array(cardType).readonly().optional(),
     bigText: bigText.optional(),
-    players: z.array(player.or(text)).min(1).readonly(),
+    players: z
+      .array(player.or(text).or(space).or(z.literal("space")))
+      .min(1)
+      .readonly(),
   })
   .strict()
   .readonly();
@@ -119,6 +130,8 @@ export interface Card extends z.infer<typeof card> {}
 export interface Player extends z.infer<typeof player> {}
 
 export interface Text extends z.infer<typeof text> {}
+
+export interface Space extends z.infer<typeof space> {}
 
 export interface HanabiGameState
   extends z.infer<typeof hanabiGameStateSchema> {}


### PR DESCRIPTION
Improve parts of the image generating script:

1) Inline `text` sections shouldn't change player names
2) Add a new `space` section to avoid the `text: ""` hack. It is also configurable with custom height.
3) Introduce a new `offset` property on players, to avoid hard coding player names in the images.
  (I don't think they're ever going to change, but with this I believe it's easier to reorganize the images.)
4) Document these changes on the example page.

Also change some images to use new functionality, to show the improvement. More to come later.