### PR TITLE
Modify challenge questions, Level 4

### DIFF
--- a/docs/challenge-questions/level-4.mdx
+++ b/docs/challenge-questions/level-4.mdx
@@ -3,12 +3,12 @@ title: Level 4 Challenge Questions
 ---
 
 import Question1 from "./level-4/level-4-question-1.yml";
-import Solution1Part1 from "./level-4/level-4-question-1-part-2.yml";
-import Solution1Part2 from "./level-4/level-4-question-1-part-3.yml";
+import Answer1Part1 from "./level-4/level-4-answer-1-part-1.yml";
+import Answer1Part2 from "./level-4/level-4-answer-1-part-2.yml";
 import Question2Part1 from "./level-4/level-4-question-2-part-1.yml";
 import Question2Part2 from "./level-4/level-4-question-2-part-2.yml";
 import Question2Part3 from "./level-4/level-4-question-2-part-3.yml";
-import Solution2 from "./level-4/level-4-question-2-part-4.yml";
+import Answer2 from "./level-4/level-4-answer-2.yml";
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
@@ -42,13 +42,13 @@ These questions are for [level 4](../level-4.mdx) strategies.
 - As a result, his slot 3 card must have been in his starting hand, while his slot 2 card must have been drawn after playing the blue 3.
 - Thus, his slot 2 card is a "fresh" one and his slot 3 card is a "normal" one from the starting hand.
 
-<Solution1Part1 />
+<Answer1Part1 />
 
 - As established in level 3, [unknown 1's are supposed to be played in a particular order](../level-3.mdx#playing-multiple-1s). Specifically, [fresh 1's are supposed to have precedence](../level-3.mdx#part-2---the-fresh-1s-rule).
 - This means that Bob was expected to play his slot 2 card instead of his slot 3 card.
 - Thus, Cathy knows that Bob intended for an _Order Chop Move_. Cathy _Chop Moves_ her slot 3 card. Her new chop is slot 2, so that would be the slot that Cathy would discard next.
 
-<Solution1Part2 />
+<Answer1Part2 />
 
 </TabItem>
 </Tabs>
@@ -99,7 +99,7 @@ These questions are for [level 4](../level-4.mdx) strategies.
   - Additionally, Bob knows that he has four 1s in his hand and only three 1s need to be played. Thus, from _Good Touch Principle_, his 1 on slot 4 will never play, so he marks it as known-trash.
   - Bob plays his slot 2 one. It successfully plays as yellow 1. (Since this is expected, it does not _Chop Move_ any player.)
 
-<Solution2 />
+<Answer2 />
 
 </TabItem>
 </Tabs>

--- a/docs/challenge-questions/level-4/level-4-answer-1-part-1.yml
+++ b/docs/challenge-questions/level-4/level-4-answer-1-part-1.yml
@@ -9,21 +9,18 @@ players:
             - Hand
           color: Gray
       - type: b
-        middleNote: (3)
-        clue: b
+        above: Blue 3
+        below: Plays
       - type: x
       - type: b
-        middleNote: (4)
-        clue: b
+        above: Blue 4
       - type: x
-  - text: "After playing blue 3:"
   - name: Bob
     cards:
       - type: x
         middleNote: (1)
         below:
-          text:
-            - Fresh
+          text: Fresh
           color: Green
       - type: x
         middleNote: (1)
@@ -34,18 +31,16 @@ players:
           color: Gray
       - type: x
       - type: b
-        middleNote: (4)
-        clue: b
+        above: Blue 4
+        below: Plays
       - type: x
-  - text: "After playing blue 4:"
   - name: Bob
     cards:
       - type: x
       - type: x
         middleNote: (1)
         below:
-          text:
-            - Fresh
+          text: Fresh
           color: Green
       - type: x
         middleNote: (1)
@@ -54,5 +49,26 @@ players:
             - Starting
             - Hand
           color: Gray
+      - type: x
+      - type: x
+  - text: "After getting the 1 clue:"
+  - space
+  - name: Bob
+    cards:
+      - type: x
+      - type: 1
+        clue: 1
+        middleNote: 1st
+        below:
+          text: Fresh
+          color: Green
+      - type: 1
+        clue: 1
+        middleNote: 2nd
+        below:
+          text:
+            - Starting
+            - "Hand,"
+            - Plays
       - type: x
       - type: x

--- a/docs/challenge-questions/level-4/level-4-answer-1-part-2.yml
+++ b/docs/challenge-questions/level-4/level-4-answer-1-part-2.yml
@@ -4,9 +4,10 @@ stacks:
   - g: 1
   - b: 5
   - p: 0
+bigText:
+  text: Early Game
 players:
-  - clueGiver: true
-    cards:
+  - cards:
       - type: x
       - type: x
       - type: x
@@ -17,18 +18,17 @@ players:
       - type: x
       - type: 1
         below:
-          text:
-            - Fresh
+          text: Fresh
           color: Green
       - type: x
       - type: x
   - cards:
       - type: x
       - type: x
+        below: Chop
       - type: x
-        above:
-          text:
-            - Chop
-            - Move
+        cm: true
+        middleNote: cm
+        below: cm
       - type: 2
       - type: 2

--- a/docs/challenge-questions/level-4/level-4-answer-2.yml
+++ b/docs/challenge-questions/level-4/level-4-answer-2.yml
@@ -12,7 +12,6 @@ players:
       - type: x
       - type: x
       - type: x
-        middleNote: (r1)
   - cards:
       - type: 1
         clue: 1
@@ -27,12 +26,12 @@ players:
             - + Chop
           color: green
       - type: r
-        middleNote: (r2)
+        middleNote: r2
       - type: 1
         clue: 1
         retouched: true
         trash: true
-        middleNote: 4th
+        middleNote: kt
         below:
           text:
             - Starting
@@ -51,4 +50,3 @@ players:
       - type: x
       - type: x
       - type: x
-        middleNote: (b1)

--- a/docs/challenge-questions/level-4/level-4-question-1.yml
+++ b/docs/challenge-questions/level-4/level-4-question-1.yml
@@ -4,6 +4,8 @@ stacks:
   - g: 0
   - b: 5
   - p: 0
+bigText:
+  text: Early Game
 players:
   - clueGiver: true
     cards:
@@ -18,6 +20,7 @@ players:
         clue: 1
       - type: 1
         clue: 1
+        below: Plays
       - type: x
       - type: x
   - cards:

--- a/docs/challenge-questions/level-4/level-4-question-2-part-2.yml
+++ b/docs/challenge-questions/level-4/level-4-question-2-part-2.yml
@@ -16,7 +16,8 @@ players:
       - type: x
       - type: r
         clue: r
-        middleNote: (r2)
+        middleNote: r2
+        below: Play
       - type: 1
         middleNote: 4th
       - type: 1

--- a/docs/challenge-questions/level-4/level-4-question-2-part-3.yml
+++ b/docs/challenge-questions/level-4/level-4-question-2-part-3.yml
@@ -18,7 +18,7 @@ players:
       - type: 1
         clue: 1
       - type: r
-        middleNote: (r2)
+        middleNote: r2
       - type: 1
         clue: 1
         retouched: true


### PR DESCRIPTION
Update or add answers to challenge questions on Level 4.

Additional notes:

Q1: Again, removing the "(3)" and "(4)" notation. Keeping the "(1)"s. Arguably, the cards could be morphed to being 1s in the first place, but Bob isn't aware of that yet, and morphing them after the clue makes it clearer, IMO.

Q2: In the answer, slot 4 is known trash, and not 4th in line to play. (And the "(b1)" and "(r1)" marks seem to be erroneous.)