### PR TITLE
Image enhancements, Level 17

### DIFF
--- a/docs/level-17.mdx
+++ b/docs/level-17.mdx
@@ -73,7 +73,7 @@ import TimeTravelChopMoveDirect from "./level-17/time-travel-chop-move-direct-fo
   - Blue 1 is played on the stacks.
   - Alice holds a globally known yellow 1.
   - Alice clues number 1 to Cathy, touching a blue 1 in slot 3 as a _Play Clue_.
-  - Bob knows that since the blue 1 was represented as a good 1, this must be a _Trash Finesse_, and Bob must have a red 1, a green 1, a yellow 1, or a purple 1 on his _Finesse Position_.
+  - Bob knows that since the blue 1 was represented as a good 1, this must be a _Trash Finesse_, and Bob must have a red 1, a green 1, or a purple 1 on his _Finesse Position_.
   - Bob blind-plays his _Finesse Position_. To his surprise, it is a yellow 1 and it successfully plays on the stacks.
   - Since yellow 1 was duplicated, the rest of the team knows that something unusual has happened. However, since no additional cards were touched as part of the clue, everyone knows that it was an _Assisted Chop Move_ on Cathy. (In this case, Cathy should _Chop Move_ slot 4 and slot 5.)
 

--- a/docs/level-17/assisted-trash-chop-move-trash-finesse.yml
+++ b/docs/level-17/assisted-trash-chop-move-trash-finesse.yml
@@ -14,9 +14,8 @@ players:
       - type: x
   - cards:
       - type: x
-        above: yellow 1
-        middleNote: (f)
-        below: plays
+        above: Yellow 1
+        below: Finesse
       - type: x
       - type: x
       - type: x
@@ -24,20 +23,22 @@ players:
   - cards:
       - type: x
       - type: x
-      - type: 1
+      - type: b1
         clue: 1
-        above: Blue 1
+        below: Play
       - type: x
       - type: x
   - text: After Bob plays yellow 1...
-  - name: Cathy
+  - offset: -1
     cards:
       - type: x
       - type: x
-      - type: 1
-        middleNote: b1
+      - type: b1
+        middleNote: kt
         trash: true
       - type: x
+        cm: true
         middleNote: cm
       - type: x
+        cm: true
         middleNote: cm

--- a/docs/level-17/assisted-trash-chop-move-utd.yml
+++ b/docs/level-17/assisted-trash-chop-move-utd.yml
@@ -17,28 +17,30 @@ players:
       - type: x
       - type: x
         above: Yellow 1
-        middleNote: (f)
-        below: plays
+        below: Discharge
       - type: x
       - type: x
   - cards:
       - type: x
-      - type: b
+      - type: b1
         clue: b
-        above: Blue 1
+        below: Play
       - type: x
       - type: x
       - type: x
   - text: After Bob discharges yellow 1...
-  - name: Cathy
+  - offset: -1
     cards:
       - type: x
-      - type: b
-        middleNote: b1
+      - type: b1
+        middleNote: kt
         trash: true
       - type: x
+        cm: true
         middleNote: cm
       - type: x
+        cm: true
         middleNote: cm
       - type: x
+        cm: true
         middleNote: cm

--- a/docs/level-17/duplicitous-blind-play.yml
+++ b/docs/level-17/duplicitous-blind-play.yml
@@ -14,9 +14,8 @@ players:
       - type: x
   - cards:
       - type: x
-        above: red 3
-        middleNote: (f)
-        below: plays
+        above: Red 3
+        below: Finesse
       - type: x
       - type: x
       - type: x
@@ -25,18 +24,17 @@ players:
       - type: x
       - type: x
       - type: x
-      - type: b
+      - type: b4
         clue: b
+        below: Play
       - type: x
   - text: After Bob blind-plays...
-  - name: Cathy
+  - offset: -1
     cards:
       - type: x
       - type: x
       - type: x
-      - type: b
+      - type: b4
         clue: b
-        below:
-          text:
-            - Blue 4
+        middleNote: b4
       - type: x

--- a/docs/level-17/duplicitous-tempo-clue.yml
+++ b/docs/level-17/duplicitous-tempo-clue.yml
@@ -17,9 +17,11 @@ players:
       - type: 2
         clue: 2
         above: Red 2
-        below: plays
+        middleNote: b2
+        below: Play
       - type: g2
         clue: 2
+        middleNote: g2
         retouched: true
       - type: x
       - type: x
@@ -30,11 +32,21 @@ players:
       - type: r2
       - type: x
   - text: After Bob plays red 2...
-  - name: Bob
+  - offset: -2
     cards:
       - type: x
       - type: x
       - type: g2
+        middleNote: g2
       - type: x
       - type: x
+        cm: true
         middleNote: cm
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: r2
+        middleNote: kt
+        trash: true
+      - type: x

--- a/docs/level-17/duplicitous-value-clue.yml
+++ b/docs/level-17/duplicitous-value-clue.yml
@@ -17,22 +17,17 @@ players:
       - type: 3
         clue: 3
         above: Red 3
-        below: plays
+        middleNote: b3
+        below: Play
       - type: 3
         clue: 3
       - type: x
       - type: x
-  - text: After Bob plays red 3....
-  - name: Bob
+  - text: After Bob plays red 3...
+  - offset: -1
     cards:
       - type: x
       - type: x
       - type: 3
-        below:
-          text:
-            - Blue 3
-            - Yellow 3
-            - Green 3
-            - Purple 3
       - type: x
       - type: x

--- a/docs/level-17/time-travel-chop-move-blind-play-form.yml
+++ b/docs/level-17/time-travel-chop-move-blind-play-form.yml
@@ -15,12 +15,13 @@ players:
   - cards:
       - type: x
         above: Blue 2
-        middleNote: f
-        below: plays
+        middleNote: r2
+        below: Finesse
+      - type: x
       - type: r3
         clue: 3
+        middleNote: r3
         retouched: true
-      - type: x
       - type: x
       - type: x
   - cards:
@@ -30,13 +31,24 @@ players:
       - type: b2
       - type: x
   - text: After Bob blind-plays blue 2...
-  - name: Bob
+  - offset: -2
     cards:
       - type: x
+      - type: x
+        cm: true
+        middleNote: cm
       - type: r3
       - type: x
+        cm: true
         middleNote: cm
       - type: x
+        cm: true
         middleNote: cm
+  - cards:
       - type: x
-        middleNote: cm
+      - type: x
+      - type: x
+      - type: b2
+        middleNote: kt
+        trash: true
+      - type: x

--- a/docs/level-17/time-travel-chop-move-direct-form.yml
+++ b/docs/level-17/time-travel-chop-move-direct-form.yml
@@ -17,7 +17,7 @@ players:
       - type: 3
         clue: 3
         above: Red 3
-        below: plays
+        below: Play
       - type: x
       - type: x
       - type: x
@@ -28,13 +28,24 @@ players:
       - type: x
       - type: r3
   - text: After Bob plays red 3...
-  - name: Bob
+  - offset: -2
     cards:
       - type: x
       - type: x
       - type: x
+        cm: true
         middleNote: cm
       - type: x
+        cm: true
         middleNote: cm
       - type: x
+        cm: true
         middleNote: cm
+  - cards:
+      - type: x
+      - type: x
+      - type: x
+      - type: x
+      - type: r3
+        middleNote: kt
+        trash: true


### PR DESCRIPTION
Notes: In Time Travel, blind form: Moved the clued card one slot back to clarify the extent of the chop moves.
