### PR TITLE
Fix wording in Trash Finesse explanation

### DIFF
--- a/docs/level-14.mdx
+++ b/docs/level-14.mdx
@@ -83,7 +83,7 @@ import ShoutDiscardOrderChopMove from "./level-14/shout-discard-order-chop-move.
   - Alice clues number 1 to Donald, which touches two green 1's on slot 1 and 2. To Donald, this will look like it is both the red 1 and the blue 1.
   - Like in the previous example, Bob sees that Cathy has a red 1 on her _Finesse Position_.
   - At first glance, Bob might think that Alice is promising both red 1 and blue 1, which would mean that he would need to blind-play the blue 1.
-  - However, a _Trash Finesse_ only promises at least one matching card, and since he sees that Cathy has a matching card, then that is good enough. Thus, Bob discards.
+  - However, a _Trash Finesse_ only promises one matching card, and since he sees that Cathy has a matching card, then that is good enough. Thus, Bob discards.
   - Cathy blind-plays her _Finesse Position_ card and it is red 1.
   - Donald knows that the focus of the clue (slot 1) is certainly trash, since that caused Cathy to blind-play.
   - Furthermore, Donald knows that his slot 2 card is also trash, because all the cards touched in a _Trash Finesse_ are guaranteed to be trash.


### PR DESCRIPTION
"only promises at least one" --> "only promises"