### PR TITLE
Remove tocm-looking discard after pink positional clue

### DIFF
--- a/docs/variant-specific/pink.mdx
+++ b/docs/variant-specific/pink.mdx
@@ -225,7 +225,7 @@ These conventions apply to any variant with a pink (touched by all ranks) suit.
   - The pink 4 is played and all of the other 3's are played.
   - Bob's hand is completely unclued.
   - Alice clues Bob number 2, touching slot 1, slot 2, and slot 3.
-  - Bob knows that since all of the 3's are already played, this might be a _Trash Chop Move_. If this is the case, he should mark these three cards as trash and then chop move slot 4 and slot 5.
+  - Bob knows that since all of the 3's are already played, this might be a _Trash Chop Move_. If this is the case, he should mark the touched cards as trash and then _Chop Move_ slot 4 and slot 5.
   - However, Bob also knows that it is near the end of the game and there are no cards left to chop move, so this interpretation does not make much sense.
   - Thus, Bob knows that this must be a _Positional Clue_, and he plays his slot 2 card as the pink 5.
 - _Positional Clues_ are different from _Pink Choice Tempo Clues_ in that they can touch new cards. (_Pink Choice Tempo Clues_ only re-touch known pink cards.) For this reason, _Positional Clues_ can typically only be done at the end of the game when the clue is not likely to be interpreted as anything else.


### PR DESCRIPTION
Idk if this is true but it seems to me like this is an artifact from when kt was discarded right to left. (Again idk if that was ever the case but why else would Bob be discarding slot 3)

Updated to remove any possible discussion of trash ocm.