### PR TITLE
Expand the landing page with more links into the documentation

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,6 +46,12 @@ const config: Config = {
       },
       items: [
         {
+          to: "about",
+          activeBasePath: "docs",
+          label: "About",
+          position: "left",
+        },
+        {
           to: "beginner",
           activeBasePath: "docs",
           label: "Beginner",
@@ -67,6 +73,12 @@ const config: Config = {
           to: "variant-specific",
           activeBasePath: "docs",
           label: "Variant-Specific",
+          position: "left",
+        },
+        {
+          to: "glossary",
+          activeBasePath: "docs",
+          label: "Glossary",
           position: "left",
         },
         {

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -29,14 +29,21 @@ const FeatureList: FeatureItem[] = [
     num: 3,
     title: "Reference Document",
     iconName: "list-ul",
-    description: <>Look up something specific.</>,
+    description: <>Look up a specific convention.</>,
     link: "reference",
+  },
+  {
+    num: 4,
+    title: "Glossary",
+    iconName: "info",
+    description: <>Common terms.</>,
+    link: "glossary",
   },
 ];
 
 function Feature({ num, title, iconName, description, link }: FeatureItem) {
   return (
-    <div className={`col col--4 ${styles["feature"]}`}>
+    <div className={`col col--6 ${styles["feature"]}`}>
       <div className="text--center">
         <br />
         <a href={useBaseUrl(link)}>


### PR DESCRIPTION
* Add more links to the top of the landing page (and each page)
* Link to the glossary on the main page, making a 2x2 grid instead of a 1x3 grid.