### PR TITLE
Update brown.mdx

### DIFF
--- a/docs/variant-specific/brown.mdx
+++ b/docs/variant-specific/brown.mdx
@@ -21,7 +21,7 @@ These conventions apply to any variant with a brown (touched by no ranks) suit.
 
 - Normally, if a _Tempo Clue_ retouches two or more cards, only the leftmost card should play.
 - When a brown color clue retouches two or more cards, only the rightmost card should play.
-- This convention also applies if brown cards are re-clued to perform a _Finesse_.
+- This "rightmost focus" convention also applies if brown cards are re-clued to perform a _Finesse_.
 
 ### The Double Clue Inversion (Immediate Double Clue)
 


### PR DESCRIPTION
It's a minor change to clarify that this applies on Tempo Clue Inversion and Double Tempo Clue Inversion also. The way this section is laid out, it seems Brown Tempo Clue is a separate topic from Tempo Clue Inversion and Double Tempo Clue Inversion, which doesn't make much sense.