### PR TITLE
Changing Orange Double Finesse example to avoid confusion with Defiant Bluff

### DIFF
--- a/docs/variant-specific/orange.mdx
+++ b/docs/variant-specific/orange.mdx
@@ -15,10 +15,11 @@ These conventions apply to any variant with an orange (inverted) suit.
 - This concept works identically for a _Double Finesse_.
 - For example, in a 4-player game:
   - It is the first turn of the game and nothing is played on the stacks.
-  - Alice clues orange to Donald, touching an orange 3 on slot 1 as a _Play Clue_.
-  - Bob blind-discards his _Finesse Position_. It is orange 1 and it successfully plays on the stacks.
-  - Cathy blind-discards her _Finesse Position_. It is orange 2 and it successfully plays on the stacks.
-  - Donald knows that he has the orange 3 to match the two blind-discards.
+  - Alice clues orange to Bob, touching an orange 3 on slot 1 as a _Play Clue_.
+  - Bob does something unrelated.
+  - Cathy blind-discards her _Finesse Position_. It is orange 1 and it successfully plays on the stacks.
+  - Donald blind-discards his _Finesse Position_. It is orange 2 and it successfully plays on the stacks.
+  - Bob knows that he has the orange 3 to match the two blind-discards.
 
 ### The Non-Orange Rank Play Clue Assumption
 


### PR DESCRIPTION
This example changes when Orange is played with Defiant Bluff turned on. By changing this example to a reverse double finesse it works at all levels. 