### PR TITLE
Add Orange layered moves. Avoid orange confusion.

### DIFF
--- a/docs/variant-specific/orange.mdx
+++ b/docs/variant-specific/orange.mdx
@@ -178,12 +178,6 @@ These conventions apply to any variant with an orange (inverted) suit.
     - Thus, Bob blind-plays his _Third Finesse Position_. It is a red 2 and successfully plays.
     - Cathy marks her card as orange 1, since that is the only way that this type of clue would cause a _Discharge_.
 - If an _Orange Trash Discharge_ touches two or more trash cards, then only the focus is promised to be an orange card. The leftmost trash card is considered to be focused, since that is the card that would be discarded first.
-- For example, in a 3-player game:
-  - All the 1s are played on the stacks.
-  - Alice clues number 1 to Cathy, touching an orange 1 on slot 2 and another 1 on slot 4.
-  - Bob sees that this is an _Orange Trash Discharge_.
-  - Thus, Bob blind-plays his _Third Finesse Position_. It is a red 2 and successfully plays.
-  - Cathy marks her slot 2 card as orange 1, and her slot 4 card as any non-orange 1.
 
 ### The Orange Fix Clue Bluff
 


### PR DESCRIPTION
* Use "drag to discard" and "drag to stacks" for (believed) orange cards to avoid confusion
* Add _Orange Layered Finesse_ and _Orange Layered Gentleman's Discard_
* Clarify that an _Orange Baton Discard_ target is chop moved
* Add another example for _Orange Trash Discharge_
* Some small language cleanup