### PR TITLE
Update critical-save-question-3.mdx

### DIFF
--- a/docs/beginner/critical-save-question-3.mdx
+++ b/docs/beginner/critical-save-question-3.mdx
@@ -29,9 +29,11 @@ import CriticalSaveAnswer3 from "./critical-save-question-3/critical-save-answer
 <TabItem value="solution">
 
 - Bob knows that this could be a _Play Clue_ on the yellow 1.
-- However, since it touched his chop, it could also be a _Save Clue_. Since yellow 3 and yellow 4 are in the trash, a yellow clue matches those cards, so it could be yellow 3 or yellow 4.
-- It cannot be a yellow 5 since a "5 save" must be done with a number 5 clue.
-- Bob then notices that Cathy has a yellow 3 in her hand. Since there are only two copies of yellow 3 in the deck, Bob cannot have the yellow 3.
+- However, since it touched his chop, it could also be a _Save Clue_:
+  - It cannot be a yellow 2, because a yellow 2 would have to be saved with a _2 Save_.
+  - It cannot be a yellow 3, because there are only two copies of yellow 3 in the deck, and Bob sees that one copy is in the trash and one copy is in Cathy's hand.
+  - It could be a yellow 4, because one copy of yellow 4 is in the trash.
+  - It cannot be a yellow 5, because a yellow 5 would have to be saved with a _5 Save_.
 - Bob does not know whether or not this is a _Play Clue_ or a _Save Clue_, but he has to treat it as a _Save Clue_ for the time being until he gets more information.
 - Bob writes a _card note_ that includes the following identities:
   - yellow 1 (as a _Play Clue_)


### PR DESCRIPTION
Add why the card could not be a yellow 5.
I forgot that a 5 save HAD to be done with a 5 clue and it took me a while to figure out why the 5 option was not mentioned.